### PR TITLE
Update .gitignore to exclude Roo files and admin documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,16 @@ coverage
 
 # Bun
 .bun
+
+# Admin documentation
+ADMIN_NOTES.md
+
+# Roo files
+.roomodes
+.roorules-architect
+.roorules-ask
+.roorules-code
+.roorules-debug
+.roorules-test
+memory-bank/
+projectBrief.md


### PR DESCRIPTION
This PR updates the .gitignore file to exclude Roo files and admin documentation.

## Changes

- Update .gitignore to exclude Roo files
- Update .gitignore to exclude admin documentation

## Security Enhancements

- Ensures sensitive local files are not committed to the repository

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author